### PR TITLE
.gitignore: remove duplicate build/ entry (already on L. 11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,4 +83,3 @@ Thumbs.db
 
 # GitHub Copilot
 copilot.json
-build/


### PR DESCRIPTION
as said multiple times, `build/` was already in .gitignore from the beginning; no need to add it a second time
